### PR TITLE
Change username to email in token request payload

### DIFF
--- a/custom_components/deyecloud/api.py
+++ b/custom_components/deyecloud/api.py
@@ -8,7 +8,7 @@ async def async_get_token(session: aiohttp.ClientSession, username, password, ap
     url = f"{base_url}/account/token?appId={app_id}"
     payload = {
         "appSecret": app_secret,
-        "username": username,
+        "email": username,
         "password": _sha256(password),
     }
     async with session.post(url, json=payload, timeout=10) as resp:

--- a/custom_components/deyecloud/sensor.py
+++ b/custom_components/deyecloud/sensor.py
@@ -57,7 +57,7 @@ async def _async_get_token(session: aiohttp.ClientSession, username, password, a
     _LOGGER.debug("Requesting token from API: %s", url)
     payload = {
         "appSecret": app_secret,
-        "username": username,
+        "email": username,
         "password": _sha256(password),
     }
     async with session.post(url, json=payload, timeout=10) as resp:


### PR DESCRIPTION
username is no longer working. Per https://developer.deyecloud.com/start, payload should contain email.